### PR TITLE
Fix RugCheck parsing, add tests

### DIFF
--- a/rugcheck.py
+++ b/rugcheck.py
@@ -8,43 +8,58 @@ from pumpfun_sniper.config import settings
 from pumpfun_sniper.db import log
 
 THRESHOLDS = {
- "holders": 50,
- "lp_locked_pct": 70,
- "creator_balance_pct": 10,
- "market_cap_usd": 2000,
+    "holders": 50,
+    "lp_locked_pct": 70,
+    "creator_balance_pct": 10,
+    "market_cap_usd": 2000,
 }
 
+
 async def fetch(mint: str) -> dict:
- """Fetch full token report from RugCheck."""
- url = f"https://api.rugcheck.xyz/v1/tokens/{mint}/report"
- async with httpx.AsyncClient(timeout=10) as cli:
- r = await cli.get(url)
- r.raise_for_status()
- return r.json()
+    """Fetch full token report from RugCheck."""
+    url = f"https://api.rugcheck.xyz/v1/tokens/{mint}/report"
+    async with httpx.AsyncClient(timeout=10) as cli:
+        r = await cli.get(url)
+        r.raise_for_status()
+        return r.json()
+
 
 def is_good(tok: dict) -> bool:
- try:
- holders = tok.get("totalHolders", 0)
- lp_locked = tok.get("lpLockedPct") or 0
- supply = tok["token"]["supply"]
- decimals = tok["token"]["decimals"]
- creator_pct = tok.get("creatorBalance", 0) / supply * 100
- market_cap = tok.get("price", 0) * (supply / (10 ** decimals))
- return (
- holders >= THRESHOLDS["holders"]
- and lp_locked >= THRESHOLDS["lp_locked_pct"]
- and creator_pct <= THRESHOLDS["creator_balance_pct"]
- and market_cap >= THRESHOLDS["market_cap_usd"]
- )
- except (KeyError, TypeError, ZeroDivisionError):
- return False
+    """Return True if token report meets quality thresholds."""
+    try:
+        holders = tok.get("totalHolders", 0)
+        lp_locked = tok.get("lpLockedPct") or 0
+
+        token_info = tok.get("token") or {}
+        decimals = token_info.get("decimals", 0) if isinstance(token_info, dict) else 0
+
+        markets = tok.get("markets") or []
+        supply = 0
+        if markets and isinstance(markets[0], dict):
+            supply = markets[0].get("lp", {}).get("tokenSupply", 0)
+
+        creator_balance = tok.get("creatorBalance", 0)
+        creator_pct = creator_balance / supply * 100 if supply else 0
+
+        price = tok.get("price", 0)
+        market_cap = price * (supply / (10**decimals)) if supply else 0
+
+        return (
+            holders >= THRESHOLDS["holders"]
+            and lp_locked >= THRESHOLDS["lp_locked_pct"]
+            and creator_pct <= THRESHOLDS["creator_balance_pct"]
+            and market_cap >= THRESHOLDS["market_cap_usd"]
+        )
+    except (KeyError, TypeError, ZeroDivisionError):
+        return False
+
 
 async def wait_until_good(mint: str, timeout_sec: int) -> bool:
- """Poll RugCheck until thresholds met or timeout."""
- for _ in range(timeout_sec // settings.RUG_RECHECK_SEC):
- tok = await fetch(mint)
- if is_good(tok):
- return True
- await asyncio.sleep(settings.RUG_RECHECK_SEC)
- await log("INFO", f"RugCheck failed for {mint[:8]}… after {timeout_sec}s")
- return False
+    """Poll RugCheck until thresholds met or timeout."""
+    for _ in range(timeout_sec // settings.RUG_RECHECK_SEC):
+        tok = await fetch(mint)
+        if is_good(tok):
+            return True
+        await asyncio.sleep(settings.RUG_RECHECK_SEC)
+    await log("INFO", f"RugCheck failed for {mint[:8]}… after {timeout_sec}s")
+    return False

--- a/tests/test_rugcheck.py
+++ b/tests/test_rugcheck.py
@@ -1,0 +1,109 @@
+import asyncio
+import types
+import os
+import pathlib
+import sys
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+for var in [
+    "HELIUS_WSS",
+    "RUGCHECK_KEY",
+    "BIRDEYE_KEY",
+    "BASE_WALLET",
+    "KEYPAIR_PATH",
+    "DB_DSN",
+]:
+    os.environ.setdefault(var, "test")
+
+import types
+
+sys.modules["pumpfun_sniper.db"] = types.SimpleNamespace(log=lambda *a, **k: None)
+import pumpfun_sniper.rugcheck as rugcheck
+
+
+@pytest.mark.asyncio
+async def test_is_good_true():
+    token = {
+        "totalHolders": 60,
+        "lpLockedPct": 80,
+        "creatorBalance": 200000000000,
+        "price": 1,
+        "token": {"decimals": 9},
+        "markets": [{"lp": {"tokenSupply": 2000000000000}}],
+    }
+    assert rugcheck.is_good(token)
+
+
+@pytest.mark.asyncio
+async def test_is_good_false():
+    token = {
+        "totalHolders": 10,
+        "lpLockedPct": 10,
+        "creatorBalance": 100000000000,
+        "price": 0.5,
+        "token": {"decimals": 9},
+        "markets": [{"lp": {"tokenSupply": 100000000000}}],
+    }
+    assert not rugcheck.is_good(token)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_good_succeeds(monkeypatch):
+    good = {
+        "totalHolders": 60,
+        "lpLockedPct": 80,
+        "creatorBalance": 200000000000,
+        "price": 1,
+        "token": {"decimals": 9},
+        "markets": [{"lp": {"tokenSupply": 2000000000000}}],
+    }
+    bad = {
+        "totalHolders": 10,
+        "lpLockedPct": 10,
+        "creatorBalance": 100000000000,
+        "price": 0.5,
+        "token": {"decimals": 9},
+        "markets": [{"lp": {"tokenSupply": 100000000000}}],
+    }
+
+    calls = 0
+
+    async def fake_fetch(mint: str):
+        nonlocal calls
+        calls += 1
+        return good if calls > 1 else bad
+
+    async def fake_log(level, msg):
+        return None
+
+    monkeypatch.setattr(rugcheck, "fetch", fake_fetch)
+    monkeypatch.setattr(rugcheck, "log", fake_log)
+    monkeypatch.setattr(rugcheck.settings, "RUG_RECHECK_SEC", 1)
+
+    assert await rugcheck.wait_until_good("mint", timeout_sec=2)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_good_timeout(monkeypatch):
+    bad = {
+        "totalHolders": 10,
+        "lpLockedPct": 10,
+        "creatorBalance": 100000000000,
+        "price": 0.5,
+        "token": {"decimals": 9},
+        "markets": [{"lp": {"tokenSupply": 100000000000}}],
+    }
+
+    async def fake_fetch(mint: str):
+        return bad
+
+    async def fake_log(level, msg):
+        return None
+
+    monkeypatch.setattr(rugcheck, "fetch", fake_fetch)
+    monkeypatch.setattr(rugcheck, "log", fake_log)
+    monkeypatch.setattr(rugcheck.settings, "RUG_RECHECK_SEC", 1)
+
+    assert not await rugcheck.wait_until_good("mint", timeout_sec=0)


### PR DESCRIPTION
## Summary
- fix supply/decimals parsing in `rugcheck.py`
- implement async unit tests covering RugCheck logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e099f10883318d506840dadc209c