### PR TITLE
Fix Helius logsSubscribe parameter

### DIFF
--- a/helius_watcher.py
+++ b/helius_watcher.py
@@ -32,7 +32,10 @@ async def helius_loop() -> None:
         "jsonrpc": "2.0",
         "id": 1,
         "method": "logsSubscribe",
-        "params": [{"mentions": [PUMP_FUN_PROGRAM]}, "processed"],
+        "params": [
+            {"mentions": [PUMP_FUN_PROGRAM]},
+            {"commitment": "processed"},
+        ],
     }
     try:
         dbg(f"HELIUS connect {settings.HELIUS_WSS}")


### PR DESCRIPTION
## Summary
- fix `logsSubscribe` call to use a config object

## Testing
- `python -m pip install --user -r requirements.txt`
- `ENV_PATH=pumpfun_sniper/.env timeout 5 python -m pumpfun_sniper.main`

------
https://chatgpt.com/codex/tasks/task_e_68847d03c1808331a2423154d95bf9e7