### PR TITLE
Exit on first Ctrl-C

### DIFF
--- a/helius_watcher.py
+++ b/helius_watcher.py
@@ -78,4 +78,6 @@ async def helius_loop() -> None:
                     await s.commit()
                 await log("INFO", f"NEW candidate {name} ({sym}) {mint[:8]}…")
     except Exception as e:
+        if isinstance(e, asyncio.CancelledError):
+            raise
         await log("ERROR", f"helius watcher failed: {e}")

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ position monitor, and the FastAPI dashboard (Uvicorn in a background thread).
 """
 
 import os
+import sys
+import signal
 import asyncio, uvicorn
 
 from pumpfun_sniper.db import init, async_session, Candidate
@@ -12,6 +14,14 @@ from pumpfun_sniper.strategy import process_candidate
 from pumpfun_sniper.executor import monitor_loop
 from pumpfun_sniper.dashboard import app
 from pumpfun_sniper.config import settings
+
+
+def _exit_handler(signum, frame):
+    """Exit immediately on Ctrl-C."""
+    print("Received SIGINT, exiting...", flush=True)
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, _exit_handler)
 
 async def _eval_loop():
     while True:


### PR DESCRIPTION
## Summary
- exit immediately when SIGINT is raised
- don't swallow CancelledError in helius watcher

## Testing
- `python -m pip install --user -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884820506a8833199bd6a9683555013