### PR TITLE
Fix invalid logsSubscribe parameter

### DIFF
--- a/helius_watcher.py
+++ b/helius_watcher.py
@@ -10,7 +10,7 @@ from pumpfun_sniper.config import settings
 from pumpfun_sniper.db import session_ctx, SeenName, BlockedCreator, Candidate, log
 from pumpfun_sniper.debug import dbg
 
-PUMP_FUN_PROGRAM = "Pump11111111111111111111111111111111111111"
+PUMP_FUN_PROGRAM = "Pump1111111111111111111111111111111111111111"
 
 # Regex helpers for metadata parsing ------------------------------------------
 NAME_RE = re.compile(rb"name\x04(.+?)\x00")


### PR DESCRIPTION
## Summary
- add missing characters to Pump Fun program constant

## Testing
- `python -m pip install --user -r requirements.txt`
- `python -m pumpfun_sniper.main` *(fails: RUGCHECK_KEY and KEYPAIR_PATH missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884831b041c8331b82a61d579d37a28