### PR TITLE
Fix Helius program configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 # Sample environment configuration for pumpfun_sniper
 HELIUS_WSS=wss://example.com/?api-key=YOUR_HELIUS_KEY
+PUMP_FUN_PROGRAM=Pump1111111111111111111111111111111111111111
 RUGCHECK_KEY=YOUR_RUGCHECK_KEY
 BIRDEYE_KEY=YOUR_BIRDEYE_KEY
 RPC_HTTP=https://api.mainnet-beta.solana.com

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All state lives in Postgres tables created at first run:
 |-------|---------|
 | `seen_names` | Block repeated token names |
 | `blocked_creators` | Addresses that rugged early |
+| PUMP_FUN_PROGRAM | pump.fun program ID | Pump1111111111111111111111111111111111111111
 | `candidates` | Mint + metadata + status (NEW, REJECTED, BOUGHT) |
 | `open_positions` | Size, avg price, dynamic stop/TP |
 | `closed_positions` | Trade history + PnL |

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+import os
+__path__ = [os.path.join(os.path.dirname(__file__), "pumpfun_sniper")]

--- a/pumpfun_sniper/config.py
+++ b/pumpfun_sniper/config.py
@@ -5,6 +5,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     # ─── External endpoints ──────────────────────────────────────────────
     HELIUS_WSS: str  # wss://mainnet.helius-rpc.com/?api-key=…
+    PUMP_FUN_PROGRAM: str = "Pump1111111111111111111111111111111111111111"
     RUGCHECK_KEY: str
     BIRDEYE_KEY: str
     RPC_HTTP: str = "https://api.mainnet-beta.solana.com"

--- a/pumpfun_sniper/helius_watcher.py
+++ b/pumpfun_sniper/helius_watcher.py
@@ -10,7 +10,8 @@ from pumpfun_sniper.config import settings
 from pumpfun_sniper.db import session_ctx, SeenName, BlockedCreator, Candidate, log
 from pumpfun_sniper.debug import dbg
 
-PUMP_FUN_PROGRAM = "Pump1111111111111111111111111111111111111111"
+# Program ID to watch for mint events
+PUMP_FUN_PROGRAM = settings.PUMP_FUN_PROGRAM
 
 # Regex helpers for metadata parsing ------------------------------------------
 NAME_RE = re.compile(rb"name\x04(.+?)\x00")


### PR DESCRIPTION
## Summary
- allow overriding the Pump.fun program id via `.env`
- document new `PUMP_FUN_PROGRAM` variable
- set up package wrapper so tests can import `pumpfun_sniper`

## Testing
- `pytest -q`
- `python -m pumpfun_sniper.main` *(fails: server rejected WebSocket connection: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68848990741c8331b5bf5d4ca11091a5